### PR TITLE
Fix: $image can contain query string and this breaks pathinfo parsing

### DIFF
--- a/Block/Catalog/Product/Breadcrumbs.php
+++ b/Block/Catalog/Product/Breadcrumbs.php
@@ -48,7 +48,7 @@ class Breadcrumbs extends BaseBreadcrumbs
         ProductRepositoryInterface $productRepository,
         Template\Context $context,
         array $data = [],
-        Json $serializer = null
+        ?Json $serializer = null
     ) {
         parent::__construct($context, $data, $serializer);
 

--- a/Model/Property.php
+++ b/Model/Property.php
@@ -118,9 +118,8 @@ final class Property implements PropertyInterface
     {
         // needed as in newer magento versions (2.4.8) this can be: http://website.com/media/catalog/product/i/m/img_6657.jpg?width=265&height=265&store=default&image-type=image
         // the query must be stripped out
-        $extension = strtolower(pathinfo($image, PATHINFO_EXTENSION)); //@codingStandardsIgnoreLine
-
         $image = parse_url($image, PHP_URL_PATH);
+
         $extension = strtolower(pathinfo($image, PATHINFO_EXTENSION)); //@codingStandardsIgnoreLine
         if (in_array($extension, $this->validImageFormats)) {
             return $this->addProperty('image', $image);

--- a/Model/Property.php
+++ b/Model/Property.php
@@ -116,6 +116,11 @@ final class Property implements PropertyInterface
      */
     public function setImage(string $image)
     {
+        // needed as in newer magento versions (2.4.8) this can be: http://website.com/media/catalog/product/i/m/img_6657.jpg?width=265&height=265&store=default&image-type=image
+        // the query must be stripped out
+        $extension = strtolower(pathinfo($image, PATHINFO_EXTENSION)); //@codingStandardsIgnoreLine
+
+        $image = parse_url($image, PHP_URL_PATH);
         $extension = strtolower(pathinfo($image, PATHINFO_EXTENSION)); //@codingStandardsIgnoreLine
         if (in_array($extension, $this->validImageFormats)) {
             return $this->addProperty('image', $image);

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "web200/magento-seo",
+    "version": "1.99.99",
     "description": "Magento 2 Seo Module",
     "require": {
         "php": "^7.0|^8.0"


### PR DESCRIPTION
On Magento 2.4.8 (possible earier versions) when the media library uses the new dynamic urls instead of the legacy ones an exception occurs:

$image can initially be:

`http://website.com/media/catalog/product/i/m/img_6657.jpg?width=265&height=265&store=default&image-type=image`

which pathinfo converts to:

`jpg?width=265&height=265&store=default&image-type=image`

The extension check fails next.